### PR TITLE
Added users/self endpoint

### DIFF
--- a/server/src/models/users/users.controller.ts
+++ b/server/src/models/users/users.controller.ts
@@ -19,6 +19,13 @@ export class UsersController {
         return this.usersService.findAll(q);
     }
 
+    @Get('self')
+    async findUserSelf(@Auth() auth)  {
+        //gets the user's id based on their JWT
+        var user = await this.usersService.findById(auth.userId);
+        return user;
+    }
+
     @Get(':id/public')
     async findOnePublic(@Param('id') id: string)  {
         var user = await this.usersService.findById(id);


### PR DESCRIPTION
@navroopsingh1 pointed out there is no way to find out the user Id to get their own user using `GET api/users/{id}`, to combat this, I created a new endpoint `GET api/users/self` that returns the user object for the ID encrypted in the JWT token. 